### PR TITLE
fixed the bug of '\0' in the hash string

### DIFF
--- a/ngx_http_upstream_consistent_hash_module.c
+++ b/ngx_http_upstream_consistent_hash_module.c
@@ -153,7 +153,7 @@ ngx_http_upstream_init_consistent_hash(ngx_conf_t *cf,
     for (i = 0; i < us->servers->nelts; i++) {
         for (j = 0; j < server[i].naddrs; j++) {
             for (k = 0; k < ((MMC_CONSISTENT_POINTS * server[i].weight) / server[i].naddrs); k++) {
-                ngx_snprintf(hash_data, 28, "%V-%ui", &server[i].addrs[j].name, k);
+                ngx_snprintf(hash_data, HASH_DATA_LENGTH, "%V-%ui%Z", &server[i].addrs[j].name, k);
                 continuum->nodes[continuum->nnodes].sockaddr = server[i].addrs[j].sockaddr;
                 continuum->nodes[continuum->nnodes].socklen = server[i].addrs[j].socklen;
                 continuum->nodes[continuum->nnodes].name = server[i].addrs[j].name;


### PR DESCRIPTION
Sorry for my last bad pull request. There is a bug with it. The ngx_snprintf() does not add the '\0' to the end of string. It breaks the compatibility with php-memcache.
